### PR TITLE
fix(db): use trigger for ts_search and ensure uuidv7() compatibility (PostgreSQL 18 beta)

### DIFF
--- a/docker/postgres/init/01-init-schema.sql
+++ b/docker/postgres/init/01-init-schema.sql
@@ -1,7 +1,7 @@
 CREATE EXTENSION IF NOT EXISTS unaccent;
 
 CREATE TABLE IF NOT EXISTS veiculo (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid_v7(),
+    id UUID PRIMARY KEY DEFAULT uuidv7(),
     marca VARCHAR(100) NOT NULL,
     modelo VARCHAR(100) NOT NULL,
     ano_fabricacao INT NOT NULL,
@@ -14,11 +14,19 @@ CREATE TABLE IF NOT EXISTS veiculo (
     tipo_transmissao VARCHAR(50) NOT NULL,
     preco NUMERIC(10, 2) NOT NULL CHECK (preco > 0),
     data_criacao TIMESTAMPTZ NOT NULL DEFAULT (now() at time zone 'utc'),
-    ts_search TSVECTOR GENERATED ALWAYS AS (
-        to_tsvector('portuguese', unaccent(marca) || ' ' || unaccent(modelo) || ' ' || unaccent(cor) || ' ' || unaccent(tipo_combustivel))
-    ) STORED,
+    ts_search TSVECTOR,
     CONSTRAINT ano_valido CHECK (ano_fabricacao >= 1990 AND ano_modelo >= ano_fabricacao AND ano_modelo <= EXTRACT(YEAR FROM now()) + 1)
 );
+
+CREATE OR REPLACE FUNCTION veiculo_tsvector_trigger() RETURNS trigger AS $$
+BEGIN
+  NEW.ts_search := to_tsvector('portuguese', unaccent(NEW.marca) || ' ' || unaccent(NEW.modelo) || ' ' || unaccent(NEW.cor) || ' ' || unaccent(NEW.tipo_combustivel));
+  RETURN NEW;
+END
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER tsvectorupdate BEFORE INSERT OR UPDATE
+    ON veiculo FOR EACH ROW EXECUTE FUNCTION veiculo_tsvector_trigger();
 
 CREATE INDEX IF NOT EXISTS idx_veiculo_marca_modelo ON veiculo (marca, modelo);
 CREATE INDEX IF NOT EXISTS idx_veiculo_ano_fabricacao ON veiculo (ano_fabricacao DESC);


### PR DESCRIPTION
- Changes ts_search to a regular column with a trigger for automatic update
- Ensures compatibility with uuidv7() on PostgreSQL 18 beta
- Schema tested and validated in a real container

Closes #4 (Define vehicle schema)