### PR TITLE
chore(gitignore): ignore Python artifacts, venvs, and editor files for best practices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,23 @@
 __pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+*.so
+*.egg-info/
+*.egg
+*.log
+*.sqlite3
+*.db
+
+# Ambientes virtuais
+.venv/
+venv/
+env/
+ENV/
+
+# Arquivos temporários de editor
+.vscode/
+.idea/
+*.swp
+*~
+.DS_Store


### PR DESCRIPTION
This PR updates the .gitignore to:
- Ignore Python build/cache artifacts (pyc, pyo, egg-info, etc.)
- Ignore virtual environments (.venv/, venv/, env/, ENV/)
- Ignore common editor and OS files (.vscode/, .idea/, .DS_Store, etc.)

This ensures a clean repository and prevents unnecessary files from being tracked.

Please review and merge into develop as per gitflow.