### PR TITLE
feat(client,server): clean LLM output and standardize MCP range tools

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,16 +1,10 @@
-# --- Database Configuration ---
 POSTGRES_USER=admin
 POSTGRES_PASSWORD=secret
 POSTGRES_DB=veiculos_db
 DATABASE_URL=postgresql+asyncpg://admin:secret@db:5432/veiculos_db
 
-# --- Agent and LLM Configuration ---
-# LLM provider. Options: OPENAI, GOOGLE, DEEPSEEK
-# Model name for the selected provider (e.g., gpt-4o, gemini-1.5-pro-latest, deepseek-chat)
 LLM_PROVIDER=OPENAI
 LLM_MODEL=gpt-4-turbo
 LLM_API_KEY=sk-#####
 
-# --- MCP Servers Configuration ---
-# Format: TRANSPORT_TYPE,ADDRESS_OR_COMMAND
 MCP_SERVERS=SSE,http://server:8000/mcp

--- a/client/main.py
+++ b/client/main.py
@@ -137,7 +137,7 @@ def format_tool_result_for_user(tool_name, tool_result):
 
     if tool_name == "buscar_veiculos":
         vehicles = tool_result if isinstance(tool_result, list) else []
-        print_vehicle_list_aligned(vehicles)
+        # Não exibir lista antes da LLM
         return f"Encontrei {len(vehicles)} veículo(s) com base na sua busca." if vehicles else "Não encontrei veículos com os critérios especificados."
 
     elif tool_name in ["listar_marcas", "listar_modelos", "listar_cores_disponiveis"]:
@@ -145,13 +145,11 @@ def format_tool_result_for_user(tool_name, tool_result):
         if not items: return "Não encontrei nenhuma opção disponível."
         noun = "marcas" if "marcas" in tool_name else "modelos" if "modelos" in tool_name else "cores"
         msg = f"As {noun} disponíveis são: {', '.join(items)}."
-        stream_print(msg)
         return msg
 
     elif tool_name == "obter_range_anos":
         anos = tool_result if isinstance(tool_result, dict) else {}
         msg = f"Temos veículos fabricados entre {anos.get('min_year')} e {anos.get('max_year')}."
-        stream_print(msg)
         return msg
 
     elif tool_name == "obter_range_precos":
@@ -164,14 +162,11 @@ def format_tool_result_for_user(tool_name, tool_result):
             max_price = float(precos.get('max_price', 0.0))
             max_price_str = f"{max_price:,.2f}".replace(",", "X").replace(".", ",").replace("X", ".")
         except (ValueError, TypeError): max_price_str = "0,00"
-        
         msg = f"Os preços dos nossos veículos variam de R$ {min_price_str} a R$ {max_price_str}."
-        stream_print(msg)
         return msg
     
-    formatted_result = json.dumps(tool_result, ensure_ascii=False, indent=2)
-    stream_print(formatted_result)
-    return formatted_result
+    # Não exibir resultado formatado cru
+    return ""
 
 
 def format_tool_result_for_llm(tool_name, tool_result):
@@ -287,8 +282,7 @@ async def main_async():
                     final_response_llm = llm.chat(messages_for_summary)
                     final_text = extract_final_response(final_response_llm)
                     final_text = clean_llm_response(final_text)
-                    if final_text and not (user_facing_msg and final_text in user_facing_msg):
-                        stream_print(final_text)
+                    if final_text: stream_print(final_text)
                     conversation.append({"role": "assistant", "content": final_response_llm})
                 else:
                     error_message = f"Desculpe, ocorreu um erro ao tentar consultar a informação. Tente novamente."

--- a/client/mcp_client.py
+++ b/client/mcp_client.py
@@ -1,7 +1,3 @@
-"""
-Módulo para comunicação com servidores MCP (Model Context Protocol).
-Inclui descoberta dinâmica de tools e chamada de tools via JSON-RPC.
-"""
 import os
 import httpx
 import json
@@ -12,7 +8,6 @@ class MCPClient:
         self.tools = []
 
     async def list_tools(self):
-        """Descobre as tools disponíveis no servidor MCP."""
         payload = {
             "jsonrpc": "2.0",
             "method": "tools/list",
@@ -27,7 +22,6 @@ class MCPClient:
             return self.tools
 
     async def call_tool(self, name: str, arguments: dict, id: int = 2):
-        """Chama uma tool MCP específica."""
         payload = {
             "jsonrpc": "2.0",
             "method": "tools/call",
@@ -40,6 +34,5 @@ class MCPClient:
             return resp.json()
 
 def get_mcp_clients():
-    """Lê MCP_SERVERS do .env e retorna instâncias de MCPClient."""
     servers = os.getenv('MCP_SERVERS', '').splitlines()
     return [MCPClient(url.split(',')[1].strip()) for url in servers if ',' in url] 

--- a/scripts/generate_inserts.py
+++ b/scripts/generate_inserts.py
@@ -14,7 +14,6 @@ OUTPUT_DIR = Path(__file__).parent.parent / "docker" / "postgres" / "init"
 OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
 OUTPUT_FILE = OUTPUT_DIR / "02-populate-data.sql"
 
-# Realistic data for the Brazilian market (data in pt-BR)
 brands_models = {
     'Ford': ['Ka', 'Fiesta', 'Focus', 'EcoSport', 'Ranger'],
     'Chevrolet': ['Onix', 'Prisma', 'Cruze', 'S10', 'Tracker'],

--- a/server/models.py
+++ b/server/models.py
@@ -23,7 +23,6 @@ class Veiculo(Base):
     preco = Column(Numeric(10, 2), nullable=False)
     data_criacao = Column(TIMESTAMP(timezone=True), server_default=text("now() at time zone 'utc'"))
 
-# Pydantic models para entrada/saída das tools
 class VehicleFilter(BaseModel):
     search_text: Optional[str] = None
     brand: Optional[str] = None
@@ -82,4 +81,8 @@ class YearRangeOut(BaseModel):
 
 class PriceRangeOut(BaseModel):
     min_price: float
-    max_price: float 
+    max_price: float
+
+class KmRangeOut(BaseModel):
+    min_km: int
+    max_km: int 

--- a/server/tools.py
+++ b/server/tools.py
@@ -1,7 +1,7 @@
 from sqlalchemy import select, func, distinct
 from sqlalchemy.ext.asyncio import AsyncSession
 from typing import List, Optional, Dict
-from models import Veiculo, VehicleFilter, VehicleResult, BrandListOut, ModelListOut, YearRangeOut, PriceRangeOut
+from models import Veiculo, VehicleFilter, VehicleResult, BrandListOut, ModelListOut, YearRangeOut, PriceRangeOut, KmRangeOut
 
 async def buscar_veiculos(db: AsyncSession, filters: VehicleFilter) -> List[VehicleResult]:
     query = select(Veiculo)
@@ -29,7 +29,6 @@ async def buscar_veiculos(db: AsyncSession, filters: VehicleFilter) -> List[Vehi
         query = query.where(Veiculo.numero_portas == filters.doors)
     if filters.transmission:
         query = query.where(Veiculo.tipo_transmissao == filters.transmission)
-    # TODO: search_text (full-text search)
     result = await db.execute(query)
     veiculos = result.scalars().all()
     return [VehicleResult.from_orm(v) for v in veiculos]
@@ -57,11 +56,11 @@ async def obter_range_precos(db: AsyncSession) -> PriceRangeOut:
     min_price, max_price = result.one()
     return PriceRangeOut(min_price=float(min_price), max_price=float(max_price))
 
-async def obter_range_km(db: AsyncSession) -> dict:
+async def obter_range_km(db: AsyncSession) -> KmRangeOut:
     from sqlalchemy import func
     result = await db.execute(select(func.min(Veiculo.quilometragem), func.max(Veiculo.quilometragem)))
     min_km, max_km = result.one()
-    return {"min_km": int(min_km), "max_km": int(max_km)}
+    return KmRangeOut(min_km=int(min_km), max_km=int(max_km))
 
 async def listar_cores_disponiveis(db: AsyncSession) -> Dict[str, List[str]]:
     result = await db.execute(select(distinct(Veiculo.cor)))


### PR DESCRIPTION
- Only show LLM responses to user, never raw MCP tool results
- Standardize obter_range_km to use Pydantic model and match other range tools
- Improve tool descriptions and prompt examples
- Remove all code comments for delivery
- Minor doc and UX improvements

This PR improves the user experience and ensures all tool outputs are consistent and clean for the agent.